### PR TITLE
Timing fixes

### DIFF
--- a/analysis/event_display/cnn_mpmt_event_display.py
+++ b/analysis/event_display/cnn_mpmt_event_display.py
@@ -57,7 +57,7 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
     """
     This class extends the CNNmPMTDataset class to provide event display functionality.
     """
-    def plot_data_2d(self, data, channel=None, transformations=None, **kwargs):
+    def plot_data_2d(self, data, channel=None, transforms=None, **kwargs):
         """
         Plots CNN mPMT data as a 2D event-display-like image.
 
@@ -67,7 +67,7 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
             Array of PMT data formatted for use in CNN, i.e. with dimensions of (channels, x, y)
         channel : str
             Name of the channel to plot. By default, plots whatever is provided by the dataset.
-        transformations : function or str or sequence of function or str, optional
+        transforms : function or str or sequence of function or str, optional
             Transformation function, or the name of a method of the dataset, or a sequence of functions or method names
             to apply to the data, such as those used for augmentation.
         kwargs : optional
@@ -97,8 +97,8 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
         columns = self.mpmt_positions[:, 1]
         data_nan = np.full_like(data, np.nan)  # fill an array with nan for positions where there's no actual PMTs
         data_nan[:, rows, columns] = data[:, rows, columns]  # replace the nans with the data where there is a PMT
-        if transformations is not None:
-            data_nan = self.apply_transformation(transformations, data_nan)
+        if transforms is not None:
+            data_nan = self.apply_transform(transforms, data_nan)
         if channel is not None:
             data_nan = data_nan[self.channel_ranges[channel]]
         coordinates = coordinates_from_data(data_nan)  # coordinates corresponding to each element of the data array
@@ -106,7 +106,7 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
         mpmt_coordinates = coordinates[((~np.isnan(data_nan)) & (np.indices(data_nan.shape)[0] == 18)).flatten()]
         return plot_event_2d(data_nan.flatten(), coordinates, mpmt_coordinates, **kwargs)
 
-    def plot_event_2d(self, event, channel=None, transformations=None, **kwargs):
+    def plot_event_2d(self, event, channel=None, transforms=None, **kwargs):
         """
         Plots an event as a 2D event-display-like image.
 
@@ -116,7 +116,7 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
             index of the event to plot
         channel : str
             Name of the channel to plot. By default, plots whatever is provided by the dataset.
-        transformations : function or str or sequence of function or str, optional
+        transforms : function or str or sequence of function or str, optional
             Transformation function, or the name of a method of this class, or a sequence of functions or method names
             to apply to the event data, such as those used for augmentation.
         kwargs : optional
@@ -143,16 +143,16 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
         ax: matplotlib.axes.Axes
         """
         data = self[event]['data']
-        return self.plot_data_2d(data, channel, transformations=transformations, **kwargs)
+        return self.plot_data_2d(data, channel, transforms=transforms, **kwargs)
 
-    def apply_transformation(self, transformation, data):
+    def apply_transform(self, transform, data):
         """
-        Apply a transformation or sequence of transformations to data.
+        Apply a transformation or sequence of transforms to data.
 
         Parameters
         ----------
-        transformation : function or str or sequence of function or str, optional
-            Transformation function, or the name of a method of this class, or a sequence of functions or method names
+        transform : function or str or sequence of function or str, optional
+            Transform function, or the name of a method of this class, or a sequence of functions or method names
             to apply to the event data, such as those used for augmentation.
         data : array_like
             Array of PMT data formatted for use in CNN, i.e. with dimensions of (channels, x, y)
@@ -162,13 +162,13 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
         np.ndarray
             transformed data
         """
-        if isinstance(transformation, str):
-            transformation = getattr(self, transformation)
-        if callable(transformation):
-            return transformation(data)
+        if isinstance(transform, str):
+            transform = getattr(self, transform)
+        if callable(transform):
+            return transform(data)
         else:
-            for t in transformation:
-                data = self.apply_transformation(t, data)
+            for t in transform:
+                data = self.apply_transform(t, data)
             return data
 
     def plot_event_3d(self, event, geometry_file_path, channel="charge", **kwargs):

--- a/analysis/event_display/cnn_mpmt_event_display.py
+++ b/analysis/event_display/cnn_mpmt_event_display.py
@@ -104,7 +104,7 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
         mpmt_coordinates = coordinates[mpmt_locations.flatten()]  # the coordinates of where the actual mPMTs are
         return plot_event_2d(data_nan.flatten(), coordinates, mpmt_coordinates, **kwargs)
 
-    def plot_event_2d(self, event, transformations=None, **kwargs):
+    def plot_event_2d(self, event, channel=None, transformations=None, **kwargs):
         """
         Plots an event as a 2D event-display-like image.
 
@@ -112,6 +112,8 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
         ----------
         event : int
             index of the event to plot
+        channel : str
+            Name of the channel to plot. By default, plots whatever is provided by the dataset.
         transformations : function or str or sequence of function or str, optional
             Transformation function, or the name of a method of this class, or a sequence of functions or method names
             to apply to the event data, such as those used for augmentation.
@@ -139,6 +141,8 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
         ax: matplotlib.axes.Axes
         """
         data = self[event]['data']
+        if channel is not None:
+            data = data[self.channel_ranges[channel]]
         return self.plot_data_2d(data, transformations=transformations, **kwargs)
 
     def apply_transformation(self, transformation, data):
@@ -167,7 +171,7 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
                 data = self.apply_transformation(t, data)
             return data
 
-    def plot_event_3d(self, event, geometry_file_path, **kwargs):
+    def plot_event_3d(self, event, geometry_file_path, channel="charge", **kwargs):
         """
         Plots an event as a 3D event-display-like image.
 
@@ -177,6 +181,8 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
             index of the event to plot
         geometry_file_path : str
             path to the file containing 3D geometry of detector
+        channel : str
+            Name of the channel to plot. By default, plot charge.
         kwargs : optional
             Additional arguments to pass to `analysis.event_display.plot_event_3d`
             Valid arguments are:
@@ -213,7 +219,8 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
         pmt_coordinates = geo_file['position']
         data_coordinates = pmt_coordinates[self.event_hit_pmts, :]
         unhit_coordinates = np.delete(pmt_coordinates, self.event_hit_pmts, axis=0)
-        data = np.array(self.event_hit_charges)
+        hit_data = {"charge": self.event_hit_charges, "time": self.event_hit_times}
+        data = hit_data[channel]
         return plot_event_3d(data, data_coordinates, unhit_coordinates, **kwargs)
 
     def plot_geometry(self, geometry_file_path, plot=('x', 'y', 'z'), view='2d', **kwargs):

--- a/analysis/event_display/cnn_mpmt_event_display.py
+++ b/analysis/event_display/cnn_mpmt_event_display.py
@@ -5,7 +5,6 @@ import numpy as np
 from analysis.event_display.event_display import plot_event_2d, plot_event_3d
 from watchmal.dataset.cnn_mpmt.cnn_mpmt_dataset import CNNmPMTDataset
 from matplotlib.pyplot import cm
-import torch
 
 
 def channel_position_offset(channel):
@@ -94,8 +93,7 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
         """
         rows = self.mpmt_positions[:, 0]
         columns = self.mpmt_positions[:, 1]
-        data = torch.Tensor(data)
-        mpmt_locations = torch.zeros_like(data, dtype=bool)  # fill a data-like array with False
+        mpmt_locations = np.zeros_like(data, dtype=bool)  # fill a data-like array with False
         mpmt_locations[18, rows, columns] = True  # replace channel 18 with True where there is an actual mPMT
         if transformations is not None:
             data = self.apply_transformation(transformations, data)

--- a/analysis/event_display/cnn_mpmt_event_display.py
+++ b/analysis/event_display/cnn_mpmt_event_display.py
@@ -220,7 +220,7 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
         data_coordinates = pmt_coordinates[self.event_hit_pmts, :]
         unhit_coordinates = np.delete(pmt_coordinates, self.event_hit_pmts, axis=0)
         hit_data = {"charge": self.event_hit_charges, "time": self.event_hit_times}
-        data = hit_data[channel]
+        data = np.array(hit_data[channel])
         return plot_event_3d(data, data_coordinates, unhit_coordinates, **kwargs)
 
     def plot_geometry(self, geometry_file_path, plot=('x', 'y', 'z'), view='2d', **kwargs):

--- a/analysis/event_display/cnn_mpmt_event_display.py
+++ b/analysis/event_display/cnn_mpmt_event_display.py
@@ -326,13 +326,17 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
                 fig, ax = plot_event_3d(data, pmt_coordinates, **args)
             else:
                 # plotting geometry, we always want to permute PMT channels, so save and replace the flip_permutation
-                old_flip_permutation = self.flip_permutation
-                self.flip_permutation = {"h": HORIZONTAL_FLIP_MPMT_MAP,
-                                         "v": VERTICAL_FLIP_MPMT_MAP,
-                                         "b": HORIZONTAL_FLIP_MPMT_MAP[VERTICAL_FLIP_MPMT_MAP]}
+                old_h_flip_permutation = self.h_flip_permutation
+                old_v_flip_permutation = self.v_flip_permutation
+                old_rotate_permutation = self.rotate_permutation
+                self.h_flip_permutation = HORIZONTAL_FLIP_MPMT_MAP
+                self.v_flip_permutation = VERTICAL_FLIP_MPMT_MAP
+                self.rotate_permutation = HORIZONTAL_FLIP_MPMT_MAP[VERTICAL_FLIP_MPMT_MAP]
                 data = self.process_data(pmt_ids, data_map[p])
                 fig, ax = self.plot_data_2d(data, **args)
-                self.flip_permutation = old_flip_permutation
+                self.h_flip_permutation = old_h_flip_permutation
+                self.v_flip_permutation = old_v_flip_permutation
+                self.rotate_permutation = old_rotate_permutation
             figs.append(fig)
             axes.append(ax)
         return figs, axes

--- a/analysis/event_display/cnn_mpmt_event_display.py
+++ b/analysis/event_display/cnn_mpmt_event_display.py
@@ -3,7 +3,7 @@ Tools for event displays from CNN mPMT dataset
 """
 import numpy as np
 from analysis.event_display.event_display import plot_event_2d, plot_event_3d
-from watchmal.dataset.cnn_mpmt.cnn_mpmt_dataset import CNNmPMTDataset
+from watchmal.dataset.cnn_mpmt.cnn_mpmt_dataset import CNNmPMTDataset, HORIZONTAL_FLIP_MPMT_MAP, VERTICAL_FLIP_MPMT_MAP
 from matplotlib.pyplot import cm
 
 
@@ -325,8 +325,14 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
                 data = data_map[p]
                 fig, ax = plot_event_3d(data, pmt_coordinates, **args)
             else:
+                # plotting geometry, we always want to permute PMT channels, so save and replace the flip_permutation
+                old_flip_permutation = self.flip_permutation
+                self.flip_permutation = {"h": HORIZONTAL_FLIP_MPMT_MAP,
+                                         "v": VERTICAL_FLIP_MPMT_MAP,
+                                         "b": HORIZONTAL_FLIP_MPMT_MAP[VERTICAL_FLIP_MPMT_MAP]}
                 data = self.process_data(pmt_ids, data_map[p])
                 fig, ax = self.plot_data_2d(data, **args)
+                self.flip_permutation = old_flip_permutation
             figs.append(fig)
             axes.append(ax)
         return figs, axes

--- a/config/data/dataset/iwcd_cnn_short.yaml
+++ b/config/data/dataset/iwcd_cnn_short.yaml
@@ -1,7 +1,8 @@
 _target_: watchmal.dataset.cnn_mpmt.cnn_mpmt_dataset.CNNmPMTDataset
 mpmt_positions_file: /data/WatChMaL/data/IWCDshort_mPMT_image_positions.npz
-mode: ['charge']
-collapse_mode: None
+channels: ['charge']
+collapse_mpmt_channels: None
 padding_type: double_cover
-scaling_charge: [2.634658, 6.9462004]
-scaling_time: [1115.6687, 263.4307]
+channel_scaling:
+  charge: [2.634658, 6.9462004]
+  time: [1115.6687, 263.4307]

--- a/config/data/dataset/iwcd_cnn_short.yaml
+++ b/config/data/dataset/iwcd_cnn_short.yaml
@@ -2,7 +2,8 @@ _target_: watchmal.dataset.cnn_mpmt.cnn_mpmt_dataset.CNNmPMTDataset
 mpmt_positions_file: /data/WatChMaL/data/IWCDshort_mPMT_image_positions.npz
 channels: ['charge']
 collapse_mpmt_channels: None
-padding_type: double_cover
+transforms:
+  - double_cover
 channel_scaling:
   charge: [2.634658, 6.9462004]
   time: [1115.6687, 263.4307]

--- a/config/data/dataset/iwcd_cnn_short.yaml
+++ b/config/data/dataset/iwcd_cnn_short.yaml
@@ -4,5 +4,4 @@ channels: ['charge']
 transforms:
   - double_cover
 channel_scaling:
-  charge: [2.634658, 6.9462004]
-  time: [1115.6687, 263.4307]
+  time: [950, 10]

--- a/config/data/dataset/iwcd_cnn_short.yaml
+++ b/config/data/dataset/iwcd_cnn_short.yaml
@@ -1,7 +1,6 @@
 _target_: watchmal.dataset.cnn_mpmt.cnn_mpmt_dataset.CNNmPMTDataset
 mpmt_positions_file: /data/WatChMaL/data/IWCDshort_mPMT_image_positions.npz
 channels: ['charge']
-collapse_mpmt_channels: None
 transforms:
   - double_cover
 channel_scaling:

--- a/config/tasks/train/train_pointnet.yaml
+++ b/config/tasks/train/train_pointnet.yaml
@@ -12,9 +12,7 @@ data_loaders:
     batch_size: 128
     num_workers: 4
     transforms:
-      - x_flip
-      - y_flip
-      - z_flip
+      - random_reflections
   validation:
     split_key: val_idxs
     batch_size: 512

--- a/config/tasks/train/train_resnet.yaml
+++ b/config/tasks/train/train_resnet.yaml
@@ -11,10 +11,8 @@ data_loaders:
     split_key: train_idxs
     batch_size: 1024
     num_workers: 4
-    transforms:
-      - horizontal_flip
-      - vertical_flip
-      - front_back_reflection
+    pre_transforms:
+      - random_reflections
   validation:
     split_key: val_idxs
     batch_size: 1024

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -198,12 +198,13 @@ class CNNmPMTDataset(H5Dataset):
         barrel duplicated to one side, and copies of the end-caps duplicated, rotated 180 degrees and with PMT channels
         in the mPMTs permuted, to provide two 'views' of the detector in one image.
         """
-        # copy the left half of the barrel (padded with zeros above and below) to the right hand side
+        # pad the image with half the barrel width
+        padded_data = np.pad(data, ((0, 0), (0, 0), (0, self.image_width//2)), mode="edge")
+        # copy the left half of the barrel to the right hand side
         left_barrel = np.array_split(data[self.barrel], 2, axis=2)[0]
-        left_barrel_padded = np.pad(left_barrel, ((0, 0), (self.endcap_size, self.endcap_size), (0, 0)))
-        padded_data = np.concatenate((data, left_barrel_padded), dim=2)
+        padded_data[:, self.endcap_size:-self.endcap_size, -self.image_width//2] = left_barrel
         # copy 180-deg rotated end-caps to the appropriate place
-        endcap_copy_left = data.shape[2] - (self.endcap_size // 2)
+        endcap_copy_left = self.image_width - (self.endcap_size // 2)
         endcap_copy_right = endcap_copy_left + self.endcap_size
         padded_data[:, :self.endcap_size, endcap_copy_left:endcap_copy_right] = self.image_flip(data[self.top_endcap], 'b')
         padded_data[:, -self.endcap_size:, endcap_copy_left:endcap_copy_right] = self.image_flip(data[self.bottom_endcap], 'b')

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -151,7 +151,7 @@ class CNNmPMTDataset(H5Dataset):
             The direction to flip the data, 'h' for horizontal, 'v' for vertical, or 'b' for a 180-deg rotation
         """
         dims = {'v': [1], 'h': [2], 'b': [1, 2]}
-        channel_permutation = self.flip_permutation[direction] if data.shape[0] == PMTS_PER_MPMT else slice(None)
+        channel_permutation = self.flip_permutation[direction]
         return np.flip(data[channel_permutation, :, :], dims[direction])
 
     def horizontal_flip(self, data):

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -25,8 +25,7 @@ class CNNmPMTDataset(H5Dataset):
     with mPMTs arrange in an event-display-like format.
     """
 
-    def __init__(self, h5file, mpmt_positions_file, padding_type=None, transforms=None, channels=None,
-                 collapse_mpmt_channels=None, channel_scaling=None):
+    def __init__(self, h5file, mpmt_positions_file, transforms=None, channels=None, collapse_mpmt_channels=None, channel_scaling=None):
         """
         Constructs a dataset for CNN data. Event hit data is read in from the HDF5 file and the PMT charge data is
         formatted into an event-display-like image for input to a CNN. Each pixel of the image corresponds to one mPMT
@@ -58,9 +57,6 @@ class CNNmPMTDataset(H5Dataset):
         super().__init__(h5file)
 
         self.mpmt_positions = np.load(mpmt_positions_file)['mpmt_image_positions']
-        self.padding_type = None
-        if padding_type is not None:
-            self.padding_type = getattr(self, padding_type)
         self.transforms = du.get_transformations(self, transforms)
         if channels is None:
             channels = ['charge', 'time']

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -76,7 +76,6 @@ class CNNmPMTDataset(H5Dataset):
         self.channel_ranges = {}
         self.h_flip_permutation = []
         self.v_flip_permutation = []
-        self.rotate_permutation = {'v': np.array([], dtype=int), 'h': np.array([], dtype=int)}
         for c in channels:
             channel_depth = 2 if c in collapse_mpmt_channels else 19 if c in ("charge", "time") else 1
             self.channel_ranges[c] = range(self.image_depth, self.image_depth+channel_depth)
@@ -176,8 +175,8 @@ class CNNmPMTDataset(H5Dataset):
         detector about its axis. The channels of the PMTs within mPMTs also have the appropriate permutation applied.
         """
         # Vertical and horizontal flips of the endcaps
-        data[self.top_endcap] = self.rotate_image(self.top_endcap)
-        data[self.bottom_endcap] = self.rotate_image(self.bottom_endcap)
+        data[self.top_endcap] = self.rotate_image(data[self.top_endcap])
+        data[self.bottom_endcap] = self.rotate_image(data[self.bottom_endcap])
         # Roll the barrel around by half the columns
         data[self.barrel] = np.roll(data[self.barrel], self.image_width // 2, 2)
         return data

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -4,6 +4,7 @@ Class implementing a mPMT dataset for CNNs in h5 format
 
 # generic imports
 import numpy as np
+import torch
 
 # WatChMaL imports
 from watchmal.dataset.h5_dataset import H5Dataset
@@ -124,7 +125,7 @@ class CNNmPMTDataset(H5Dataset):
         for c, (offset, scale) in self.scaling.items():
             hit_data[c] = (hit_data[c] - offset)/scale
         # Process the channels
-        data = np.zeros((self.image_depth, self.image_height, self.image_width))
+        data = np.zeros((self.image_depth, self.image_height, self.image_width), dtype=np.float32)
         for c, r in self.channel_ranges.items():
             channel_data = self.process_data(self.event_hit_pmts, hit_data[c])
             if c in self.collapse_channels:
@@ -135,7 +136,7 @@ class CNNmPMTDataset(H5Dataset):
         # Apply "padding" transformation e.g. for double cover
         if self.padding_type is not None:
             data = self.padding_type(data)
-        data_dict["data"] = data
+        data_dict["data"] = torch.from_numpy(data)
         return data_dict
 
     def image_flip(self, data, direction):

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -14,8 +14,11 @@ import torch
 from watchmal.dataset.h5_dataset import H5Dataset
 import watchmal.dataset.data_utils as du
 
-barrel_map_array_idxs = [6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5, 15, 16, 17, 12, 13, 14, 18]
-pmts_per_mpmt = 19
+PMTS_PER_MPMT = 19
+# maps to permute the PMTs within mPMT for various transformations, etc.
+BARREL_MPMT_MAP = np.array([6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5, 15, 16, 17, 12, 13, 14, 18])
+VERTICAL_FLIP_MPMT_MAP = np.array([6, 5, 4, 3, 2, 1, 0, 11, 10, 9, 8, 7, 15, 14, 13, 12, 17, 16, 18])
+HORIZONTAL_FLIP_MPMT_MAP = np.array([0, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 12, 17, 16, 15, 14, 13, 18])
 
 
 class CNNmPMTDataset(H5Dataset):
@@ -26,7 +29,8 @@ class CNNmPMTDataset(H5Dataset):
     with mPMTs arrange in an event-display-like format.
     """
 
-    def __init__(self, h5file, mpmt_positions_file, padding_type=None, transforms=None, mode=['charge','time'], collapse_mode=None, scaling_charge=None, scaling_time=None):
+    def __init__(self, h5file, mpmt_positions_file, padding_type=None, transforms=None, channels=None,
+                 collapse_mpmt_channels=None, channel_scaling=None):
         """
         Constructs a dataset for CNN data. Event hit data is read in from the HDF5 file and the PMT charge data is
         formatted into an event-display-like image for input to a CNN. Each pixel of the image corresponds to one mPMT
@@ -42,249 +46,180 @@ class CNNmPMTDataset(H5Dataset):
         transforms: sequence of string
             List of random transforms to apply to data before passing to CNN for data augmentation. Each element of the
             list should be the name of a method of this class that performs the transformation
-	mode: sequence of string
-	    List defines the PMT data included in the image-like CNN arrays. It can be either 'charge', 'time' or both (default)
-        collapse_mode: sequence of string
-	    List of the data to be collapsed to two channels, containing, respectively, the mean and the std of other channels. 
-	    i.e. provides the mean and the std of PMT charges and/or time in each mPMT instead of providing all PMT data.	
-	    It can be [], ['charge'], ['time'] or ['charge', 'time']. By default no collapsing is performed.
-        scaling_charge:[offset, scale]
-	    Offset and scale to standardise the PMT charge data
-        scaling_time: [offset, scale]
-	    Offset and scale to standardise the PMT time data
-        ----------
-	"""
-	
+        channels: sequence of string
+            List defines the PMT data included in the image-like CNN arrays. It can be either 'charge', 'time' or both
+            (default)
+        collapse_mpmt_channels: sequence of string
+            List of the data to be collapsed to two channels, containing, respectively, the mean and the std of other
+            channels. i.e. provides the mean and the std of PMT charges and/or time in each mPMT instead of providing
+            all PMT data. It can be [], ['charge'], ['time'] or ['charge', 'time']. By default, no collapsing is
+            performed.
+        channel_scaling: dict of (int, int)
+            Dictionary with keys corresponding to channels and values contain the offset and scale to use. By default,
+            no scaling is applied.
+"""
+
         super().__init__(h5file)
 
         self.mpmt_positions = np.load(mpmt_positions_file)['mpmt_image_positions']
-        self.data_size = np.max(self.mpmt_positions, axis=0) + 1
-        self.barrel_rows = [row for row in range(self.data_size[0]) if
-                            np.count_nonzero(self.mpmt_positions[:, 0] == row) == self.data_size[1]]
-        n_channels = pmts_per_mpmt
-        self.data_size = np.insert(self.data_size, 0, n_channels)
-        self.transforms = du.get_transformations(self, transforms)
-
+        self.padding_type = None
         if padding_type is not None:
             self.padding_type = getattr(self, padding_type)
-        else:
-            self.padding_type = None
+        self.transforms = du.get_transformations(self, transforms)
+        if channels is None:
+            channels = ['charge', 'time']
+        if collapse_mpmt_channels is None:
+            collapse_mpmt_channels = []
+        self.collapse_channels = collapse_mpmt_channels
+        if channel_scaling is None:
+            channel_scaling = {}
+        self.scaling = channel_scaling
 
-        self.horizontal_flip_mpmt_map = [0, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 12, 17, 16, 15, 14, 13, 18]
-        self.vertical_flip_mpmt_map = [6, 5, 4, 3, 2, 1, 0, 11, 10, 9, 8, 7, 15, 14, 13, 12, 17, 16, 18]
+        self.image_height, self.image_width = np.max(self.mpmt_positions, axis=0) + 1
+        self.image_depth = 0
+        self.channel_ranges = {}
+        self.flip_permutation = {'v': np.array([], dtype=int), 'h': np.array([], dtype=int)}
+        for c in channels:
+            channel_depth = 2 if c in collapse_mpmt_channels else 19 if c in ("charge", "time") else 1
+            self.channel_ranges[c] = range(self.image_depth, self.image_depth+channel_depth)
+            # permutation maps are needed for applying transformations to the image that affect mPMT channel ordering
+            if channel_depth == PMTS_PER_MPMT:
+                self.flip_permutation['v'] = np.append(self.flip_permutation['v'], VERTICAL_FLIP_MPMT_MAP + self.image_depth)
+                self.flip_permutation['h'] = np.append(self.flip_permutation['h'], HORIZONTAL_FLIP_MPMT_MAP + self.image_depth)
+            else:
+                self.flip_permutation['v'] = np.append(self.flip_permutation['v'], self.channel_ranges[c])
+                self.flip_permutation['h'] = np.append(self.flip_permutation['h'], self.channel_ranges[c])
+            self.image_depth += channel_depth
+        self.flip_permutation['b'] = self.flip_permutation['h'][self.flip_permutation['v']]
 
-        self.mode = mode
-        if collapse_mode is None:
-            self.collapse_mode = []
-        else:
-            self.collapse_mode = collapse_mode
-
-        self.scaling_charge = scaling_charge
-        self.scaling_time = scaling_time
-
-        if self.scaling_charge is not None:
-            self.charge_offset = self.scaling_charge[0]
-            self.charge_scale = self.scaling_charge[1]
-
-        if self.scaling_time is not None:
-            self.time_offset = self.scaling_time[0]
-            self.time_scale = self.scaling_time[1] 
-            
+        # make some index expressions for different parts of the image, to use in transformations etc
+        rows, counts = np.unique(self.mpmt_positions[:, 0], return_counts=True)  # count occurrences of each row
+        # barrel rows are those where the row appears in mpmt_positions as many times as the image width
+        barrel_rows = [row for row, count in zip(rows, counts) if count == self.image_width]
+        # endcap size is the number of rows before the first barrel row
+        self.endcap_size = min(barrel_rows)
+        self.barrel = np.s_[..., self.endcap_size:max(barrel_rows) + 1, :]
+        # endcaps are assumed to be within squares centred above and below the barrel
+        endcap_left = (self.image_width - self.endcap_size) // 2
+        endcap_right = endcap_left + self.endcap_size
+        self.top_endcap = np.s_[..., :self.endcap_size, endcap_left:endcap_right]
+        self.bottom_endcap = np.s_[..., -self.endcap_size:, endcap_left:endcap_right]
 
     def process_data(self, hit_pmts, hit_data):
-        """
-        Returns event data from dataset associated with a specific index
-
-        Parameters
-        ----------
-        hit_pmts: array_like of int
-            Array of hit PMT IDs
-        hit_data: array_like of float
-            Array of PMT hit charges, or other per-PMT data
-
-        Returns
-        -------
-        data: ndarray
-            Array in image-like format (channels, rows, columns) for input to CNN network.
-        """
-        hit_mpmts = hit_pmts // pmts_per_mpmt
-        hit_pmt_in_modules = hit_pmts % pmts_per_mpmt
+        """Returns image-like event data array (channels, rows, columns) from arrays of PMT IDs and data at the PMTs."""
+        hit_mpmts = hit_pmts // PMTS_PER_MPMT
+        hit_channel = hit_pmts % PMTS_PER_MPMT
 
         hit_rows = self.mpmt_positions[hit_mpmts, 0]
         hit_cols = self.mpmt_positions[hit_mpmts, 1]
 
-        data = np.zeros(self.data_size, dtype=np.float32)
-        data[hit_pmt_in_modules, hit_rows, hit_cols] = hit_data
+        data = np.zeros((PMTS_PER_MPMT, self.image_height, self.image_width), dtype=np.float32)
+        data[hit_channel, hit_rows, hit_cols] = hit_data
 
-        # fix barrel array indexing to match endcaps in xyz ordering
-        barrel_data = data[:, self.barrel_rows, :]
-        data[:, self.barrel_rows, :] = barrel_data[barrel_map_array_idxs, :, :]
+        # fix indexing of barrel PMTs in mPMT modules to match that of endcaps in the projection to 2D
+        data[self.barrel] = data[BARREL_MPMT_MAP][self.barrel]
 
         return data
 
     def __getitem__(self, item):
-
+        """Returns image-like event data array (channels, rows, columns) for an event at a given index"""
         data_dict = super().__getitem__(item)
-
-        if 'charge' in self.mode:
-            hit_data = self.event_hit_charges
-            if self.scaling_charge is not None:
-                hit_data = self.feature_scaling_std(hit_data, self.charge_offset, self.charge_scale)
-
-            charge_image = from_numpy(self.process_data(self.event_hit_pmts, hit_data))
-            charge_image = self.padding_type(charge_image)
-
-        if 'time' in self.mode:
-            hit_data = self.event_hit_times
-            if self.scaling_time is not None:
-                hit_data = self.feature_scaling_std(hit_data, self.time_offset, self.time_scale)
-
-            time_image = from_numpy(self.process_data(self.event_hit_pmts, hit_data))
-            time_image = self.padding_type(time_image)
-
-        # Merge all channels
-        if ('time' in self.mode) and ('charge' in self.mode):
-            processed_image = torch.cat((charge_image, time_image), 0)
-            processed_image = du.apply_random_transformations(self.transforms, processed_image)
-            charge_image = processed_image[:19, :, :]
-            time_image = processed_image[19:, :, :]
-            if 'charge' in self.collapse_mode:
-                 mean_channel = torch.mean(charge_image, 0, keepdim=True)
-                 std_channel = torch.std(charge_image, 0, keepdim=True)
-                 charge_image = torch.cat((mean_channel, std_channel), 0)
-            if 'time' in self.collapse_mode:
-               	 mean_channel = torch.mean(time_image, 0, keepdim=True)
-                 std_channel = torch.std(time_image, 0, keepdim=True)
-                 time_image = torch.cat((mean_channel, std_channel), 0)
-
-            processed_image = torch.cat((charge_image, time_image), 0)
-
-        elif 'charge' in self.mode:
-            processed_image = du.apply_random_transformations(self.transforms, charge_image)
-            if 'charge' in self.collapse_mode:
-                mean_channel = torch.mean(processed_image, 0, keepdim=True)
-                std_channel = torch.std(processed_image, 0, keepdim=True)
-                processed_image = torch.cat((mean_channel, std_channel), 0)
-        else:
-            processed_image = du.apply_random_transformations(self.transforms, time_image)
-            if 'time' in self.collapse_mode:
-                 mean_channel = torch.mean(processed_image, 0, keepdim=True)
-                 std_channel = torch.std(processed_image, 0, keepdim=True)
-                 processed_image = torch.cat((mean_channel, std_channel), 0)
-
-        data_dict["data"] = processed_image
-        
+        hit_data = {"charge": self.event_hit_charges, "time": self.event_hit_times}
+        # apply scaling to channels
+        for c, (offset, scale) in self.scaling.items():
+            hit_data[c] = (hit_data[c] - offset)/scale
+        # Process the channels
+        data = torch.zeros((self.image_depth, self.image_height, self.image_width))
+        for c, r in self.channel_ranges.items():
+            channel_data = from_numpy(self.process_data(self.event_hit_pmts, hit_data[c]))
+            if c in self.collapse_channels:
+                channel_data = collapse_channel(channel_data)
+            data[r] = channel_data
+        # Apply random transformations for augmentation
+        data = du.apply_random_transformations(self.transforms, data)
+        # Apply "padding" transformation e.g. for double cover
+        if self.padding_type is not None:
+            data = self.padding_type(data)
+        data_dict["data"] = data
         return data_dict
-        
-    def horizontal_flip(self, data):
+
+    def image_flip(self, data, direction):
         """
         Takes image-like data and returns the data after applying a horizontal flip to the image.
-        The channels of the PMTs within mPMTs also have the appropriate permutation applied.
+        The channels of the PMTs within mPMTs are permuted by to flip_mpmt_map.
+
+        Parameters
+        ----------
+        data: ndarray
+            Array in image-like format (channels, rows, columns) for input to CNN network.
+        direction: ['v', 'h', 'b']
+            The direction to flip the data, 'h' for horizontal, 'v' for vertical, or 'b' for a 180-deg rotation
         """
-        flip_mpmt_map = np.tile(self.horizontal_flip_mpmt_map, data.shape[0]//19)
-        return flip(data[flip_mpmt_map, :, :], [2])
+        dims = {'v': [1], 'h': [2], 'b': [1, 2]}
+        channel_permutation = self.flip_permutation[direction] if data.shape[0] == PMTS_PER_MPMT else slice(None)
+        return flip(data[channel_permutation, :, :], dims[direction])
+
+    def horizontal_flip(self, data):
+        """Perform horizontal flip of detector to each channel, permuting mPMT channels where needed"""
+        return self.image_flip(data, 'h')
 
     def vertical_flip(self, data):
-        """
-        Takes image-like data and returns the data after applying a vertical flip to the image.
-        The channels of the PMTs within mPMTs also have the appropriate permutation applied.
-        """
-        flip_mpmt_map = np.tile(self.vertical_flip_mpmt_map, data.shape[0]//19)
-        return flip(data[flip_mpmt_map, :, :], [1])
+        """Perform vertical flip of detector to each channel, permuting mPMT channels where needed"""
+        return self.image_flip(data, 'v')
 
-    def flip_180(self, data):
-        """
-        Takes image-like data and returns the data after applying both a horizontal flip to the image. This is
-        equivalent to a 180-degree rotation of the image.
-        The channels of the PMTs within mPMTs also have the appropriate permutation applied.
-        """
-        return self.horizontal_flip(self.vertical_flip(data))
- 
     def front_back_reflection(self, data):
         """
-        Takes CNN input data in event-display-like format and returns the data with horizontal flip of the left and
-        right halves of the barrels and vertical flip of the endcaps. This is equivalent to reflecting the detector
-        swapping the front and back of the event-display view. The channels of the PMTs within mPMTs also have the
-        appropriate permutation applied.
+        Takes a dictionary of CNN input data channels in event-display-like format and returns the data with horizontal
+        flip of the left and right halves of the barrels and vertical flip of the end-caps. This is equivalent to
+        reflecting the detector swapping the front and back of the event-display view. The channels of the PMTs within
+        mPMTs also have the appropriate permutation applied.
         """
-
-        barrel_row_start, barrel_row_end = self.barrel_rows[0], self.barrel_rows[-1]
-        radius_endcap = barrel_row_start//2                     # 5
-        half_barrel_width = data.shape[2]//2                    # 20
-        l_endcap_index = half_barrel_width - radius_endcap      # 15
-        r_endcap_index = half_barrel_width + radius_endcap      # 25
-        
-        transform_data = data.clone()
-
-        # Take out the left and right halves of the barrel
-        left_barrel = data[:, self.barrel_rows, :half_barrel_width]
-        right_barrel = data[:, self.barrel_rows, half_barrel_width:]
         # Horizontal flip of the left and right halves of barrel
-        transform_data[:, self.barrel_rows, :half_barrel_width] = self.horizontal_flip(left_barrel)
-        transform_data[:, self.barrel_rows, half_barrel_width:] = self.horizontal_flip(right_barrel)
-
-        # Take out the top and bottom endcaps
-        top_endcap = data[:, :barrel_row_start, l_endcap_index:r_endcap_index]
-        bottom_endcap = data[:, barrel_row_end+1:, l_endcap_index:r_endcap_index]
+        left_barrel, right_barrel = torch.tensor_split(data[self.barrel], 2, dim=2)
+        left_barrel[:] = self.image_flip(left_barrel, 'h')
+        right_barrel[:] = self.image_flip(right_barrel, 'h')
         # Vertical flip of the top and bottom endcaps
-        transform_data[:, :barrel_row_start, l_endcap_index:r_endcap_index] = self.vertical_flip(top_endcap)
-        transform_data[:, barrel_row_end+1:, l_endcap_index:r_endcap_index] = self.vertical_flip(bottom_endcap)
-
-        return transform_data
+        data[self.top_endcap] = self.image_flip(data[self.top_endcap], 'v')
+        data[self.bottom_endcap] = self.image_flip(data[self.bottom_endcap], 'v')
+        return data
 
     def rotation180(self, data):
         """
-        Takes CNN input data in event-display-like format and returns the data with horizontal and vertical flip of the
-        endcaps and shifting of the barrel rows by half the width. This is equivalent to a 180-degree rotation of the
-        detector about its axis. The channels of the PMTs within mPMTs also have the appropriate permutation applied.
+        Takes a dictionary of CNN input data channels in event-display-like format and returns the data with horizontal
+        and vertical flip of the endcaps and shifting of the barrel rows by half the width. This is equivalent to a
+        180-degree rotation of the detector about its axis. The channels of the PMTs within mPMTs also have the
+        appropriate permutation applied.
         """
-        barrel_row_start, barrel_row_end = self.barrel_rows[0], self.barrel_rows[-1]   # 10,18 respectively
-        radius_endcap = barrel_row_start//2                 # 5
-        l_endcap_index = data.shape[2]//2 - radius_endcap   # 15
-        r_endcap_index = data.shape[2]//2 + radius_endcap   # 25   
-
-        transform_data = data.clone()
-
-        # Take out the top and bottom endcaps
-        top_endcap = data[:, :barrel_row_start, l_endcap_index:r_endcap_index]
-        bottom_endcap = data[:, barrel_row_end+1:, l_endcap_index:r_endcap_index]
         # Vertical and horizontal flips of the endcaps
-        transform_data[:, :barrel_row_start, l_endcap_index:r_endcap_index] = self.flip_180(top_endcap)
-        transform_data[:, barrel_row_end+1:, l_endcap_index:r_endcap_index] = self.flip_180(bottom_endcap)
+        data[self.top_endcap] = self.image_flip(self.top_endcap, 'b')
+        data[self.bottom_endcap] = self.image_flip(self.bottom_endcap, 'b')
+        # Roll the barrel around by half the columns
+        data[self.barrel] = torch.roll(data[self.barrel], self.image_width // 2, 2)
+        return data
 
-        # Swap the left and right halves of the barrel
-        transform_data[:, self.barrel_rows, :] = torch.roll(transform_data[:, self.barrel_rows, :], 20, 2)
-
-        return transform_data
-    
     def mpmt_padding(self, data):
         """
-        Takes CNN input data in event-display-like format and returns the data with part of the barrel duplicated to one
-        side, and copies of the end-caps duplicated, rotated 180 degrees and with PMT channels in the mPMTs permuted, to
-        provide two 'views' of the detect in one image.
+        Takes a dictionary of CNN input data channels in event-display-like format and returns the data with part of the
+        barrel duplicated to one side, and copies of the end-caps duplicated, rotated 180 degrees and with PMT channels
+        in the mPMTs permuted, to provide two 'views' of the detector in one image.
         """
-        w = data.shape[2]
-        barrel_row_start, barrel_row_end = self.barrel_rows[0], self.barrel_rows[-1]
-        l_endcap_index = w//2 - 5
-        r_endcap_index = w//2 + 4
-
-        padded_data = torch.cat((data, torch.zeros_like(data[:, :, :w//2])), dim=2)
-        padded_data[:, self.barrel_rows, w:] = data[:, self.barrel_rows, :w//2]
-
-        # Take out the top and bottom endcaps
-        top_endcap = data[:, :barrel_row_start, l_endcap_index:r_endcap_index+1]
-        bottom_endcap = data[:, barrel_row_end+1:, l_endcap_index:r_endcap_index+1]
-
-        padded_data[:, :barrel_row_start, l_endcap_index+w//2:r_endcap_index+w//2+1] = self.flip_180(top_endcap)
-        padded_data[:, barrel_row_end+1:, l_endcap_index+w//2:r_endcap_index+w//2+1] = self.flip_180(bottom_endcap)
-
+        # copy the left half of the barrel (padded with zeros above and below) to the right hand side
+        left_barrel = torch.tensor_split(data[self.barrel], 2, dim=2)[0]
+        left_barrel_padded = torch.nn.functional.pad(left_barrel, (self.endcap_size, self.endcap_size, 0, 0))
+        padded_data = torch.cat((data, left_barrel_padded), dim=2)
+        # copy 180-deg rotated end-caps to the appropriate place
+        endcap_copy_left = data.shape[2] - (self.endcap_size // 2)
+        endcap_copy_right = endcap_copy_left + self.endcap_size
+        padded_data[:, :self.endcap_size, endcap_copy_left:endcap_copy_right] = self.image_flip(data[self.top_endcap], 'b')
+        padded_data[:, -self.endcap_size:, endcap_copy_left:endcap_copy_right] = self.image_flip(data[self.bottom_endcap], 'b')
         return padded_data
 
     def double_cover(self, data):
         """
-        Takes CNN input data in event-display-like format and returns the data with all parts of the detector duplicated
-        and rearranged to provide a double-cover of the image, providing two 'views' of the detector from a single image
-        with less blank space and physically meaningful cyclic boundary conditions at the edges of the image.
+        Takes a dictionary of CNN input data channels in event-display-like format and returns the data with all parts
+        of the detector duplicated and rearranged to provide a double-cover of the image, providing two 'views' of the
+        detector from a single image with less blank space and physically meaningful cyclic boundary conditions at the
+        edges of the image.
 
         The transformation looks something like the following, where PMTs on the end caps are numbered and PMTs on the
         barrel are letters:
@@ -299,41 +234,28 @@ class CNNmPMTDataset(H5Dataset):
                              ONMXWVUSTRQP
         ```
         """
-        w = data.shape[2]                                                                            
-        barrel_row_start, barrel_row_end = self.barrel_rows[0], self.barrel_rows[-1]
-        radius_endcap = barrel_row_start//2
-        half_barrel_width, quarter_barrel_width = w//2, w//4
-
         # Step - 1 : Roll the tensor so that the first quarter is the last quarter
+        quarter_barrel_width = self.image_width // 4
         padded_data = torch.roll(data, -quarter_barrel_width, 2)
-
-        # Step - 2 : Copy the endcaps and paste 3 quarters from the start, after flipping 180 
-        l1_endcap_index = half_barrel_width - radius_endcap - quarter_barrel_width
-        r1_endcap_index = l1_endcap_index + 2*radius_endcap
-        l2_endcap_index = l1_endcap_index+half_barrel_width
-        r2_endcap_index = r1_endcap_index+half_barrel_width
-
-        top_endcap = padded_data[:, :barrel_row_start, l1_endcap_index:r1_endcap_index]
-        bottom_endcap = padded_data[:, barrel_row_end+1:, l1_endcap_index:r1_endcap_index]
-        
-        padded_data[:, :barrel_row_start, l2_endcap_index:r2_endcap_index] = self.flip_180(top_endcap)
-        padded_data[:, barrel_row_end+1:, l2_endcap_index:r2_endcap_index] = self.flip_180(bottom_endcap)
-        
-        # Step - 3 : Rotate the top and bottom half of barrel and concat them to the top and bottom respectively
-        barrel_rows_top, barrel_rows_bottom = np.array_split(self.barrel_rows, 2)
-        barrel_top_half, barrel_bottom_half = padded_data[:, barrel_rows_top, :], padded_data[:, barrel_rows_bottom, :]
-        
-        concat_order = (self.flip_180(barrel_top_half), 
-                        padded_data,
-                        self.flip_180(barrel_bottom_half))
-
-        padded_data = torch.cat(concat_order, dim=1)
-
+        # Step - 2 : Copy the endcaps and paste 3 quarters from the start, after flipping 180
+        endcap_copy_left = quarter_barrel_width - (self.endcap_size // 2)
+        endcap_copy_right = endcap_copy_left + self.endcap_size
+        top_endcap_copy = np.s_[..., :self.endcap_size, endcap_copy_left:endcap_copy_right]
+        bottom_endcap_copy = np.s_[..., -self.endcap_size:, endcap_copy_left:endcap_copy_right]
+        padded_data[top_endcap_copy] = self.image_flip(data[self.top_endcap], 'b')
+        padded_data[bottom_endcap_copy] = self.image_flip(data[self.bottom_endcap], 'b')
+        # Step - 3 : Rotate the bottom and top halves of barrel and concatenate to the top and bottom of the image
+        barrel_flipped = self.image_flip(data[self.barrel], 'b')
+        barrel_bottom_flipped, barrel_top_flipped = torch.tensor_split(barrel_flipped, 2, dim=1)
+        padded_data = torch.cat((barrel_bottom_flipped, padded_data, barrel_top_flipped), dim=1)
         return padded_data
-	
-    def feature_scaling_std(self, hit_array, offset, scale):
-        """
-            Scale data using standarization.
-        """
-        standarized_array = (hit_array - offset)/scale
-        return standarized_array
+
+
+def collapse_channel(hit_data):
+    """
+    Replaces 19 channels for the 19 PMTs within mPMT with two channels corresponding to their mean and stdev.
+    """
+    mean_channel = torch.mean(hit_data, 0, keepdim=True)
+    std_channel = torch.std(hit_data, 0, keepdim=True)
+    hit_data = torch.cat((mean_channel, std_channel), 0)
+    return hit_data

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -135,11 +135,9 @@ class CNNmPMTDataset(H5Dataset):
             if c in self.collapse_channels:
                 channel_data = collapse_channel(channel_data)
             data[r] = channel_data
-        # Apply random transformations for augmentation
-        data = du.apply_random_transformations(self.transforms, data)
-        # Apply "padding" transformation e.g. for double cover
-        if self.padding_type is not None:
-            data = self.padding_type(data)
+        # Apply transformations
+        for t in self.transforms:
+            data = t(data)
         data_dict["data"] = torch.from_numpy(data)
         return data_dict
 
@@ -183,6 +181,10 @@ class CNNmPMTDataset(H5Dataset):
         # Roll the barrel around by half the columns
         data[self.barrel] = np.roll(data[self.barrel], self.image_width // 2, 2)
         return data
+
+    def random_reflections(self, data):
+        """Takes CNN input data in event-display-like format and randomly reflects the detector about each axis"""
+        return du.apply_random_transformations([self.horizontal_flip, self.vertical_flip, self.rotation180], data)
 
     def mpmt_padding(self, data):
         """

--- a/watchmal/dataset/data_utils.py
+++ b/watchmal/dataset/data_utils.py
@@ -20,7 +20,8 @@ from watchmal.dataset.samplers import DistributedSamplerWrapper
 from torch_geometric.loader import DataLoader as PyGDataLoader
 
 
-def get_data_loader(dataset, batch_size, sampler, num_workers, is_distributed, seed, is_graph=False, split_path=None, split_key=None, transforms=None):
+def get_data_loader(dataset, batch_size, sampler, num_workers, is_distributed, seed, is_graph=False,
+                    split_path=None, split_key=None, pre_transforms=None, post_transforms=None):
     """
     Creates a dataloader given the dataset and sampler configs. The dataset and sampler are instantiated using their
     corresponding configs. If using DistributedDataParallel, the sampler is wrapped using DistributedSamplerWrapper.
@@ -47,15 +48,20 @@ def get_data_loader(dataset, batch_size, sampler, num_workers, is_distributed, s
         Path to an npz file containing an array of indices to use as a subset of the full dataset.
     split_key : string
         Name of the array to use in the file specified by split_path.
-    transforms : list of string
-        List of transforms to apply to the dataset.
+    pre_transforms : list of string
+        List of transforms to apply to the dataset before any transforms specified by the dataset config.
+    pre_transforms : list of string
+        List of transforms to apply to the dataset after any transforms specified by the dataset config.
     
     Returns
     -------
     torch.utils.data.DataLoader
         dataloader created with instantiated dataset and (possibly wrapped) sampler
     """
-    dataset = instantiate(dataset, transforms=transforms)
+    # combine transforms specified in data loader with transforms specified in dataset
+    transforms = dataset["transforms"] if (("transforms" in dataset) and (dataset["transforms"] is not None)) else []
+    transforms = (pre_transforms or []) + transforms + (post_transforms or [])
+    dataset = instantiate(dataset, transforms=(transforms or None))
     
     if split_path is not None and split_key is not None:
         split_indices = np.load(split_path, allow_pickle=True)[split_key]

--- a/watchmal/dataset/pointnet/pointnet_dataset.py
+++ b/watchmal/dataset/pointnet/pointnet_dataset.py
@@ -74,7 +74,8 @@ class PointNetDataset(H5Dataset):
             data[-2, :n_hits] = self.event_hit_times[:n_hits]
         data[-1, :n_hits] = self.event_hit_charges[:n_hits]
 
-        data = du.apply_random_transformations(self.transforms, data)
+        for t in self.transforms:
+            data = t(data)
 
         data_dict["data"] = data
         return data_dict

--- a/watchmal/dataset/pointnet/pointnet_mpmt_dataset.py
+++ b/watchmal/dataset/pointnet/pointnet_mpmt_dataset.py
@@ -63,7 +63,8 @@ class PointNetMultiPMTDataset(H5Dataset):
         data[charge_channels, unique_hit_mpmts] = self.event_hit_charges
         data[time_channels, unique_hit_mpmts] = self.event_hit_times
 
-        data = du.apply_random_transformations(self.transforms, data)
+        for t in self.transforms:
+            data = t(data)
 
         data_dict["data"] = data
         return data_dict

--- a/watchmal/dataset/pointnet/transformations.py
+++ b/watchmal/dataset/pointnet/transformations.py
@@ -1,3 +1,5 @@
+import watchmal.dataset.data_utils as du
+
 def x_flip(data):
     """Returns point-cloud formatted data with the sign flipped of the x-component of the position and direction"""
     data[0, :] = -data[0, :]
@@ -20,3 +22,7 @@ def z_flip(data):
     if data.shape[0] > 6:
         data[5] = -data[5, :]
     return data
+
+def random_reflections(data):
+    """Returns point-cloud formatted data with the position and direction randomly flipped in each axis"""
+    return du.apply_random_transformations([x_flip, y_flip, z_flip], data)


### PR DESCRIPTION
This fixes bugs in the implementation of timing for ResNet when combined with other transforms.

The way transforms are applied is significantly changed to allow it to work well with the choice of charge and/or timing channels.
Now, the augmentation transforms and double cover transform are treated the same way. They can either be specified by the transforms parameter of the dataset or the `pre_transforms` or `post_transforms` parameter of the data loader, which are applied before or after the dataset transforms, respectively.

The new parameters of the `CNNmPMTDataset` are:

`transforms`: list of names of methods to apply to the data (whether always applied, like `double_cover`, or random augmentations like the new `random_reflections` method)
`channels`: list of channels to include, i.e. `["charge"]`, `["time"]`, or `["charge", "time"]`. More might be added in future.
`collapse_mpmt_channels`: list of channels to collapse the 19 mPMT PMTs into mean and stdev
`channel_scaling`: dictionary of scaling parameters, where the key is the name of the channel (e.g. `"time"`) and the value is a tuple of (offset, scale) to scale the channel data by subtracting the offset and dividing by the scale

The changes have also been propagated to the pointnet dataset and the event display code.